### PR TITLE
allow client to specify charset for response

### DIFF
--- a/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
+++ b/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
@@ -78,6 +78,10 @@ public class HttpClientHelper {
 	}
 
 	public static <T> Future<HttpResponse<T>> requestAsync(HttpRequest request, final Class<T> responseClass, Callback<T> callback) {
+		return requestAsync(request, responseClass, callback, null);
+	}
+	
+	public static <T> Future<HttpResponse<T>> requestAsync(HttpRequest request, final Class<T> responseClass, Callback<T> callback, final String charset) {
 		HttpUriRequest requestObj = prepareRequest(request);
 
 		CloseableHttpAsyncClient asyncHttpClient = ClientFactory.getAsyncHttpClient();
@@ -104,18 +108,22 @@ public class HttpClientHelper {
 
 			public HttpResponse<T> get() throws InterruptedException, ExecutionException {
 				org.apache.http.HttpResponse httpResponse = future.get();
-				return new HttpResponse<T>(httpResponse, responseClass);
+				return new HttpResponse<T>(httpResponse, responseClass, charset);
 			}
 
 			public HttpResponse<T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
 					TimeoutException {
 				org.apache.http.HttpResponse httpResponse = future.get(timeout, unit);
-				return new HttpResponse<T>(httpResponse, responseClass);
+				return new HttpResponse<T>(httpResponse, responseClass, charset);
 			}
 		};
 	}
 
 	public static <T> HttpResponse<T> request(HttpRequest request, Class<T> responseClass) throws UnirestException {
+		return request(request, responseClass, null);
+	}
+	
+	public static <T> HttpResponse<T> request(HttpRequest request, Class<T> responseClass, String charset) throws UnirestException {
 		HttpRequestBase requestObj = prepareRequest(request);
 		HttpClient client = ClientFactory.getHttpClient(); // The
 															// DefaultHttpClient
@@ -124,7 +132,7 @@ public class HttpClientHelper {
 		org.apache.http.HttpResponse response;
 		try {
 			response = client.execute(requestObj);
-			HttpResponse<T> httpResponse = new HttpResponse<T>(response, responseClass);
+			HttpResponse<T> httpResponse = new HttpResponse<T>(response, responseClass, charset);
 			requestObj.releaseConnection();
 			return httpResponse;
 		} catch (Exception e) {

--- a/src/main/java/com/mashape/unirest/http/HttpResponse.java
+++ b/src/main/java/com/mashape/unirest/http/HttpResponse.java
@@ -57,8 +57,12 @@ public class HttpResponse<T> {
 		return false;
 	}
 	
-	@SuppressWarnings("unchecked")
 	public HttpResponse(org.apache.http.HttpResponse response, Class<T> responseClass) {
+		this(response, responseClass, null);
+	}
+	
+	@SuppressWarnings("unchecked")
+	public HttpResponse(org.apache.http.HttpResponse response, Class<T> responseClass, String charset) {
 		HttpEntity responseEntity = response.getEntity();
 		
 		Header[] allHeaders = response.getAllHeaders();
@@ -84,10 +88,10 @@ public class HttpResponse<T> {
 				this.rawBody = inputStream;
 
 				if (JsonNode.class.equals(responseClass)) {
-					String jsonString = new String(rawBody).trim();
+					String jsonString = charset == null ? new String(rawBody).trim() : new String(rawBody, charset).trim();
 					this.body = (T) new JsonNode(jsonString);
 				} else if (String.class.equals(responseClass)) {
-					this.body = (T) new String(rawBody);
+					this.body = charset == null ? (T) new String(rawBody) : (T) new String(rawBody, charset);
 				} else if (InputStream.class.equals(responseClass)) {
 					this.body = (T) this.rawBody;
 				} else {

--- a/src/main/java/com/mashape/unirest/request/BaseRequest.java
+++ b/src/main/java/com/mashape/unirest/request/BaseRequest.java
@@ -51,25 +51,49 @@ public abstract class BaseRequest {
 	public HttpResponse<String> asString() throws UnirestException {
 		return HttpClientHelper.request(httpRequest, String.class);
 	}
+	
+	public HttpResponse<String> asString(String charset) throws UnirestException {
+		return HttpClientHelper.request(httpRequest, String.class, charset);
+	}
 
 	public Future<HttpResponse<String>> asStringAsync() {
 		return HttpClientHelper.requestAsync(httpRequest, String.class, null);
 	}
 	
+	public Future<HttpResponse<String>> asStringAsync(String charset) {
+		return HttpClientHelper.requestAsync(httpRequest, String.class, null, charset);
+	}
+	
 	public Future<HttpResponse<String>> asStringAsync(Callback<String> callback) {
 		return HttpClientHelper.requestAsync(httpRequest, String.class, callback);
+	}
+	
+	public Future<HttpResponse<String>> asStringAsync(Callback<String> callback, String charset) {
+		return HttpClientHelper.requestAsync(httpRequest, String.class, callback, charset);
 	}
 
 	public HttpResponse<JsonNode> asJson() throws UnirestException {
 		return HttpClientHelper.request(httpRequest, JsonNode.class);
+	}
+	
+	public HttpResponse<JsonNode> asJson(String charset) throws UnirestException {
+		return HttpClientHelper.request(httpRequest, JsonNode.class, charset);
 	}
 
 	public Future<HttpResponse<JsonNode>> asJsonAsync() {
 		return HttpClientHelper.requestAsync(httpRequest, JsonNode.class, null);
 	}
 	
+	public Future<HttpResponse<JsonNode>> asJsonAsync(String charset) {
+		return HttpClientHelper.requestAsync(httpRequest, JsonNode.class, null, charset);
+	}
+	
 	public Future<HttpResponse<JsonNode>> asJsonAsync(Callback<JsonNode> callback) {
 		return HttpClientHelper.requestAsync(httpRequest, JsonNode.class, callback);
+	}
+	
+	public Future<HttpResponse<JsonNode>> asJsonAsync(Callback<JsonNode> callback, String charset) {
+		return HttpClientHelper.requestAsync(httpRequest, JsonNode.class, callback, charset);
 	}
 
 	public HttpResponse<InputStream> asBinary() throws UnirestException {


### PR DESCRIPTION
Hi Team

This code change will expose methods that allow clients to specify charset for the response body. It's especially useful for CJK characters. Could you please kindly take a review and integrate it to master branch if possible?

Cheers,
Shun