### PR TITLE
added override to skip JsonNode constructor

### DIFF
--- a/src/main/java/com/mashape/unirest/http/JsonNode.java
+++ b/src/main/java/com/mashape/unirest/http/JsonNode.java
@@ -53,7 +53,12 @@ public class JsonNode {
 			}
 		}
 	}
-	
+
+	public JsonNode(JSONObject object) {
+		jsonObject = object;
+		array = false;
+	}
+
 	public JSONObject getObject() {
 		return this.jsonObject;
 	}

--- a/src/main/java/com/mashape/unirest/request/HttpRequestWithBody.java
+++ b/src/main/java/com/mashape/unirest/request/HttpRequestWithBody.java
@@ -29,6 +29,8 @@ import java.io.File;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.json.JSONObject;
+
 import com.mashape.unirest.http.HttpMethod;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.request.body.MultipartBody;
@@ -97,6 +99,10 @@ public class HttpRequestWithBody extends HttpRequest {
 		}
 		this.body = body;
 		return body;
+	}
+
+	public RequestBodyEntity body(JSONObject body) {
+		return body(new JsonNode(body));
 	}
 
 	public RequestBodyEntity body(JsonNode body) {


### PR DESCRIPTION
This makes building a request a little less awkward to do (can now pass a `JSONObject` directly instead of having to build it on `new JsonNode().getObject()`).