### PR TITLE
UNIREST-JAVA 84: Post should sort the fields as part of the request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,5 +126,11 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/mashape/unirest/http/utils/MapUtil.java
+++ b/src/main/java/com/mashape/unirest/http/utils/MapUtil.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TreeMap;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
@@ -38,7 +39,8 @@ public class MapUtil {
 	public static List<NameValuePair> getList(Map<String, List<Object>> parameters) {
 		List<NameValuePair> result = new ArrayList<NameValuePair>();
 		if (parameters != null) {
-			for(Entry<String, List<Object>> entry : parameters.entrySet()) {
+			TreeMap<String, List<Object>> sortedParameters = new TreeMap<String, List<Object>>(parameters);
+			for(Entry<String, List<Object>> entry : sortedParameters.entrySet()) {
 				List<Object> entryValue = entry.getValue();
 				if (entryValue != null) {
 					for(Object cur : entryValue) {

--- a/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
@@ -45,6 +46,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.mashape.unirest.request.HttpRequest;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.json.JSONArray;
@@ -685,5 +688,18 @@ public class UnirestTest {
 			// Ok
 		}
 	}
-	
+
+	@Test
+	public void testPostProvidesSortedParams() throws IOException {
+		// Verify that fields are encoded into the body in sorted order.
+		HttpRequest httpRequest = Unirest.post("test")
+			.field("z", "Z")
+			.field("y", "Y")
+			.field("x", "X")
+			.getHttpRequest();
+
+		InputStream content = httpRequest.getBody().getEntity().getContent();
+		String body = IOUtils.toString(content, "UTF-8");
+		assertEquals("x=X&y=Y&z=Z", body);
+	}
 }


### PR DESCRIPTION
Patch for #84 . Turns out the problem fix was in the MapUtil, which was losing even the insertion order of the keys as it turned them into a set before iteration.  Fix is to use a TreeMap rather than a regular map.  Added test, which introduces a test-time dependency Apache's io utils.

Verified that in my environment this fixes incorrectly failing tests that rely on [mock-server](http://www.mock-server.com/)