### PR TITLE
Add type to ObjectMapper readValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Unirest.setObjectMapper(new ObjectMapper() {
     private com.fasterxml.jackson.databind.ObjectMapper objectMapper 
         = new com.fasterxml.jackson.databind.ObjectMapper();
 
-    public Object readValue(String value) {
-        return objectMapper.readValue(value);
+    public <T> T readValue(String value, Class<T> type) {
+        return objectMapper.readValue(value, type);
     }
     
     public String writeValue(Object value) {

--- a/src/main/java/com/mashape/unirest/http/HttpResponse.java
+++ b/src/main/java/com/mashape/unirest/http/HttpResponse.java
@@ -97,7 +97,7 @@ public class HttpResponse<T> {
 				} else if (InputStream.class.equals(responseClass)) {
 					this.body = (T) this.rawBody;
 				} else if (objectMapper != null) {
-					this.body = (T) objectMapper.readValue(new String(rawBody, charset));
+					this.body = (T) objectMapper.readValue(new String(rawBody, charset), responseClass);
 				} else {
 					throw new Exception("Only String, JsonNode and InputStream are supported, or an ObjectMapper implementation is required.");
 				}

--- a/src/main/java/com/mashape/unirest/http/ObjectMapper.java
+++ b/src/main/java/com/mashape/unirest/http/ObjectMapper.java
@@ -2,7 +2,7 @@ package com.mashape.unirest.http;
 
 public interface ObjectMapper {
 
-    Object readValue(String value);
+    <T> T readValue(String value, Class<T> type);
 
     String writeValue(Object value);
 }

--- a/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
@@ -835,8 +835,8 @@ public class UnirestTest {
 		final String responseJson = "{\"locale\": \"english\"}";
 
 		Unirest.setObjectMapper(new ObjectMapper() {
-			public Object readValue(String ignored) {
-				return Locale.ENGLISH;
+			public <T> T readValue(String ignored, Class<T> type) {
+				return (T) Locale.ENGLISH;
 			}
 
 			public String writeValue(Object ignored) {


### PR DESCRIPTION
On your docs you state that Jackson's ObjectMapper has a `readValue(String)` method but that's not true. You need to pass the object type so that Jackson is able to deserialize the class for you.

I added the type to the `ObjectMapper` interface and update the README. Also fixed the unit test.