### PR TITLE
Fixed "missing class type in ObjectMapper" interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,23 @@ For example, serializing Json from\to Object using the popular Jackson ObjectMap
 ```java
 // Only one time
 Unirest.setObjectMapper(new ObjectMapper() {
-    private com.fasterxml.jackson.databind.ObjectMapper objectMapper 
-        = new com.fasterxml.jackson.databind.ObjectMapper();
-
-    public Object readValue(String value) {
-        return objectMapper.readValue(value);
-    }
+    private com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper
+                = new com.fasterxml.jackson.databind.ObjectMapper();
     
+    public <T> T readValue(String value, Class<T> valueType) {
+        try {
+            return jacksonObjectMapper.readValue(value, valueType);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public String writeValue(Object value) {
-        return objectMapper.writeValueAsString(value);
+        try {
+            return jacksonObjectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 });
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<jackson.version>2.6.0</jackson.version>
 	</properties>
 
 	<build>
@@ -130,6 +131,12 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/mashape/unirest/http/HttpResponse.java
+++ b/src/main/java/com/mashape/unirest/http/HttpResponse.java
@@ -97,7 +97,7 @@ public class HttpResponse<T> {
 				} else if (InputStream.class.equals(responseClass)) {
 					this.body = (T) this.rawBody;
 				} else if (objectMapper != null) {
-					this.body = (T) objectMapper.readValue(new String(rawBody, charset));
+					this.body = objectMapper.readValue(new String(rawBody, charset), responseClass);
 				} else {
 					throw new Exception("Only String, JsonNode and InputStream are supported, or an ObjectMapper implementation is required.");
 				}

--- a/src/main/java/com/mashape/unirest/http/ObjectMapper.java
+++ b/src/main/java/com/mashape/unirest/http/ObjectMapper.java
@@ -2,7 +2,7 @@ package com.mashape.unirest.http;
 
 public interface ObjectMapper {
 
-    Object readValue(String value);
+    <T> T readValue(String value, Class<T> valueType);
 
     String writeValue(Object value);
 }

--- a/src/test/java/com/mashape/unirest/http/GetResponse.java
+++ b/src/test/java/com/mashape/unirest/http/GetResponse.java
@@ -1,0 +1,19 @@
+package com.mashape.unirest.http;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GetResponse {
+
+    @JsonProperty("url")
+    private String url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/src/test/java/com/mashape/unirest/http/JacksonObjectMapper.java
+++ b/src/test/java/com/mashape/unirest/http/JacksonObjectMapper.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 
 public class JacksonObjectMapper implements ObjectMapper {
 
-    com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper
+    private com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper
             = new com.fasterxml.jackson.databind.ObjectMapper();
 
     public <T> T readValue(String value, Class<T> valueType) {

--- a/src/test/java/com/mashape/unirest/http/JacksonObjectMapper.java
+++ b/src/test/java/com/mashape/unirest/http/JacksonObjectMapper.java
@@ -1,0 +1,27 @@
+package com.mashape.unirest.http;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.IOException;
+
+public class JacksonObjectMapper implements ObjectMapper {
+
+    com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper
+            = new com.fasterxml.jackson.databind.ObjectMapper();
+
+    public <T> T readValue(String value, Class<T> valueType) {
+        try {
+            return jacksonObjectMapper.readValue(value, valueType);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String writeValue(Object value) {
+        try {
+            return jacksonObjectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Here the fix for the missing class type in the ObjectMapper interface. I added "real" Jackson @Tests (only for test scope), and updated the documentation accordingly.