### PR TITLE
Change calling to String.isEmpty() for length() > 0 to make java 1.5 …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,3 @@ jdk:
 
 os:
   - linux
-  - osx

--- a/src/main/java/com/mashape/unirest/request/body/MultipartBody.java
+++ b/src/main/java/com/mashape/unirest/request/body/MultipartBody.java
@@ -99,7 +99,7 @@ public class MultipartBody extends BaseRequest implements Body {
 		parameters.put(name, list);
 
 		ContentType type = null;
-		if (contentType != null && !contentType.isEmpty()) {
+		if (contentType != null && contentType.length() > 0) {
 			type = ContentType.parse(contentType);
 		} else if (file) {
 			type = ContentType.APPLICATION_OCTET_STREAM;


### PR DESCRIPTION
Avoid use of String.isEmpty() in com.mashape.unirest.request.body.MultipartBody to make the class 1.5 compatible.