### PR TITLE
URL encode query string keys

### DIFF
--- a/src/main/java/com/mashape/unirest/request/HttpRequest.java
+++ b/src/main/java/com/mashape/unirest/request/HttpRequest.java
@@ -107,7 +107,10 @@ public class HttpRequest extends BaseRequest {
 			queryString.append("?");
 		}
 		try {
-			queryString.append(name).append("=").append(URLEncoder.encode((value == null) ? "" : value.toString(), "UTF-8"));
+			queryString
+				.append(URLEncoder.encode(name))
+				.append("=")
+				.append(URLEncoder.encode((value == null) ? "" : value.toString(), "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/UnirestTest.java
@@ -168,6 +168,14 @@ public class UnirestTest {
 	}
 
 	@Test
+	public void testQueryStringEncoding() throws JSONException, UnirestException {
+		String testKey = "email2=someKey&email";
+		String testValue = "hello@hello.com";
+		HttpResponse<JsonNode> response = Unirest.get("http://httpbin.org/get").queryString(testKey, testValue).asJson();
+		assertEquals(testValue, response.getBody().getObject().getJSONObject("args").getString(testKey));
+	}
+
+	@Test
 	public void testDelete() throws JSONException, UnirestException {
 		HttpResponse<JsonNode> response = Unirest.delete("http://httpbin.org/delete").asJson();
 		assertEquals(200, response.getStatus());


### PR DESCRIPTION
The test and fix should pretty clearly demonstrate the issue, but a query with a key/value pair like `("foo=bar&baz", "bang")` ends up *actually* sending a request for `domainname/resource?foo=bar&baz=bang`.. that seems quite surprising and buggy to me!